### PR TITLE
Fix for issue 7

### DIFF
--- a/OpenSSL-template.podspec
+++ b/OpenSSL-template.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
     mkdir -p "${CURRENTPATH}"
     mkdir -p "${CURRENTPATH}/bin"
 
-    curl "https://openssl.org/source/openssl-${VERSION}.tar.gz" -o file.tgz
+    curl -L "https://openssl.org/source/openssl-${VERSION}.tar.gz" -o file.tgz
     cp "file.tgz" "${CURRENTPATH}/file.tgz"
     cd "${CURRENTPATH}"
     tar -xzf file.tgz


### PR DESCRIPTION
Downloading the OpenSSL source with `curl -L` to fix the redirect issue in the installation script.
